### PR TITLE
Remove unnecessary date manipulation in findCurrentYear method

### DIFF
--- a/src/application/application.service.ts
+++ b/src/application/application.service.ts
@@ -209,8 +209,6 @@ export class ApplicationService {
   }
 
   async findCurrentYear(userId: string) {
-    const now = new Date();
-    now.setHours(7, 0, 0, 0);
     const config = await this.configRepository.findOneByOrFail({
       id: 1,
     });


### PR DESCRIPTION
Eliminate redundant date manipulation in the `findCurrentYear` method to streamline the code.