### PR TITLE
Make announcement document optional and fix application submission

### DIFF
--- a/src/announcement/announcement.controller.ts
+++ b/src/announcement/announcement.controller.ts
@@ -59,7 +59,6 @@ export class AnnouncementController {
       new ParseFileFieldsPipe<CreateAnnouncementFilesDto>({
         doc: {
           type: 'application/pdf',
-          required: true,
           itemCount: 1,
         },
       }),
@@ -75,12 +74,6 @@ export class AnnouncementController {
     return this.announcementService.findAllPublic();
   }
 
-  @Public()
-  @Get(':id')
-  findOnePublic(@Param('id', ParseIntPipe) id: number) {
-    return this.announcementService.findOnePublic(id);
-  }
-
   @ApiBearerAuth()
   @Roles(Role.ADMIN)
   @Get('admin')
@@ -93,6 +86,12 @@ export class AnnouncementController {
   @Get('admin/:id')
   findOneAdmin(@Param('id', ParseIntPipe) id: number) {
     return this.announcementService.findOneAdmin(id);
+  }
+
+  @Public()
+  @Get(':id')
+  findOnePublic(@Param('id', ParseIntPipe) id: number) {
+    return this.announcementService.findOnePublic(id);
   }
 
   @ApiBearerAuth()

--- a/src/application/application.service.ts
+++ b/src/application/application.service.ts
@@ -78,6 +78,8 @@ export class ApplicationService {
       file.doc[0].buffer,
       file.doc[0].mimetype,
     );
+
+    return application.id;
   }
 
   async update(

--- a/src/models/announcement.entity.ts
+++ b/src/models/announcement.entity.ts
@@ -11,7 +11,7 @@ export class Announcement extends BaseEntity {
   @Column({ type: 'text' })
   description: string;
 
-  @Column()
+  @Column({ nullable: true })
   PDFDocument: string;
 
   @Column()


### PR DESCRIPTION
Make the announcement document optional during creation and adjust the application service to handle the absence of a document. Update the announcement entity to allow a nullable PDF document field.